### PR TITLE
Allow client to push custom headers in connect request

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class HttpProxyAgent extends http.Agent {
       host: this.proxy.hostname,
       port: this.proxy.port,
       path: `${options.host}:${options.port}`,
-      headers: { connection: this.keepAlive ? 'keep-alive' : 'close' },
+      headers: { ...options.headers, connection: this.keepAlive ? 'keep-alive' : 'close' },
       agent: false
     }
 
@@ -63,7 +63,7 @@ class HttpsProxyAgent extends https.Agent {
       host: this.proxy.hostname,
       port: this.proxy.port,
       path: `${options.host}:${options.port}`,
-      headers: { connection: this.keepAlive ? 'keep-alive' : 'close' },
+      headers: { ...options.headers, connection: this.keepAlive ? 'keep-alive' : 'close' },
       agent: false
     }
 


### PR DESCRIPTION
I think it would be nice to allow the client to pass custom headers which are then sent to proxies in the connect request