### PR TITLE
Exclude test directory from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "./": "./"
   },
+  "files": ["index.js", "index.mjs", "index.d.ts"],
   "scripts": {
     "test": "standard && ava -v test/*.test.js && tsd"
   },


### PR DESCRIPTION
Some security scanner at a customer showed that as high severity.
While this is not critical, it's good to reduce the package size at the same time.