### PR TITLE
feat:add-connect-timeout-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ const agent = new HttpProxyAgent({
   keepAliveMsecs: 1000,
   maxSockets: 256,
   maxFreeSockets: 256,
-  proxy: 'http://localhost:8080'
+  proxy: 'http://localhost:8080',
+  // proxy connect timeout in milliseconds 
+  timeout: 1000,
 })
 
 http.get('http://localhost:9200', { agent })

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ class HttpProxyAgent extends http.Agent {
       path: `${options.host}:${options.port}`,
       setHost: false,
       headers: { connection: this.keepAlive ? 'keep-alive' : 'close', host: `${options.host}:${options.port}` },
-      agent: false
+      agent: false,
+      timeout: options.timeout,
     }
 
     if (this.proxy.username || this.proxy.password) {
@@ -38,6 +39,12 @@ class HttpProxyAgent extends http.Agent {
       } else {
         callback(new Error(`Bad response: ${response.statusCode}`), null)
       }
+    })
+
+    request.once('timeout', () => {
+      const e = new Error(`connect proxy ${this.proxy.toString()} timeout`)
+      e.code = 'EPROXYTIMEOUT'
+      request.destroy(e);
     })
 
     request.once('error', err => {
@@ -66,7 +73,8 @@ class HttpsProxyAgent extends https.Agent {
       path: `${options.host}:${options.port}`,
       setHost: false,
       headers: { connection: this.keepAlive ? 'keep-alive' : 'close', host: `${options.host}:${options.port}` },
-      agent: false
+      agent: false,
+      timeout: options.timeout,
     }
 
     if (this.proxy.username || this.proxy.password) {
@@ -84,6 +92,12 @@ class HttpsProxyAgent extends https.Agent {
       } else {
         callback(new Error(`Bad response: ${response.statusCode}`), null)
       }
+    })
+
+    request.once('timeout', () => {
+      const e = new Error(`connect proxy ${this.proxy.toString()} timeout`)
+      e.code = 'EPROXYTIMEOUT'
+      request.destroy(e);
     })
 
     request.once('error', err => {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "./": "./"
   },
   "scripts": {
-    "test": "standard && ava -v test/*.test.js && tsd"
+    "test": "standard && ava -v test/*.test.js && tsd",
+    "test-got": "ava -v test/got.test.js && tsd"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The proxy maybe unavailable and keep `got` holding without connect timeout, which may keep the program hang, add support for agent connect timeout and throw `EPROXYTIMEOUT` error for caller to process timeout issue.