### PR TITLE
Fix TLS bug preventing HTTPS-over-HTTP(S) proxying

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,11 @@ class HttpsProxyAgent extends https.Agent {
       const base64 = Buffer.from(`${this.proxy.username || ''}:${this.proxy.password || ''}`).toString('base64')
       requestOptions.headers['proxy-authorization'] = `Basic ${base64}`
     }
+    
+    // Necessary for the TLS check with the proxy to succeed.
+    if (this.proxy.protocol === 'https:') {
+      requestOptions.servername = this.proxy.hostname;
+    }
 
     const request = (this.proxy.protocol === 'http:' ? http : https).request(requestOptions)
     request.once('connect', (response, socket, head) => {


### PR DESCRIPTION
Without this fix, you see this error when attempting to use an HTTPS proxy.

`Error [ERR_TLS_CERT_ALTNAME_INVALID]: Hostname/IP does not match certificate's altnames: Host: foo.com. is not in the cert's altnames: DNS:*.bar.com, DNS:bar.com`

The `servername` attribute is able to fix this behavior when passed to the underlying `tls.connect()` call inside of the `https` module. (see the Node [docs](https://nodejs.org/api/https.html#httpsrequesturl-options-callback))

This was very painful to debug but now I understand how `CONNECT` works extremely well! Cheers.

FIxes #43