### PR TITLE
Add support for proxyRequestOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ http.get('http://localhost:9200', { agent })
     .end()
 ```
 
+You can also pass custom options intended only for the proxy CONNECT request with the `proxyConnectOptions` option,
+such as headers or `tls.connect()` options:
+
+```js
+const fs = require('fs')
+const http = require('http')
+const { HttpProxyAgent } = require('hpagent')
+
+const agent = new HttpProxyAgent({
+  keepAlive: true,
+  keepAliveMsecs: 1000,
+  maxSockets: 256,
+  maxFreeSockets: 256,
+  proxy: 'https://localhost:8080',
+  proxyConnectOptions: {
+    headers: {
+      'Proxy-Authorization': 'Basic YWxhZGRpbjpvcGVuc2VzYW1l',
+    },
+    ca: [ fs.readFileSync('custom-proxy-cert.pem') ]
+  }
+})
+
+http.get('http://localhost:9200', { agent })
+    .on('response', console.log)
+    .end()
+```
+
 ## Integrations
 
 Following you can find the list of userland http libraries that are tested with this agent.

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,8 @@ declare class HttpProxyAgent extends http.Agent {
 }
 
 interface HttpProxyAgentOptions extends http.AgentOptions {
-  proxy: string | URL
+  proxy: string | URL,
+  proxyRequestOptions?: ProxyAgentRequestOptions
 }
 
 declare class HttpsProxyAgent extends https.Agent {
@@ -15,12 +16,20 @@ declare class HttpsProxyAgent extends https.Agent {
 }
 
 interface HttpsProxyAgentOptions extends https.AgentOptions {
-  proxy: string | URL
+  proxy: string | URL,
+  proxyRequestOptions?: ProxyAgentRequestOptions
+}
+
+interface ProxyAgentRequestOptions {
+  ca?: string[],
+  headers?: Object,
+  rejectUnauthorized?: boolean
 }
 
 export {
   HttpProxyAgent,
   HttpProxyAgentOptions,
   HttpsProxyAgent,
-  HttpsProxyAgentOptions
+  HttpsProxyAgentOptions,
+  ProxyAgentRequestOptions,
 }

--- a/index.js
+++ b/index.js
@@ -6,21 +6,23 @@ const { URL } = require('url')
 
 class HttpProxyAgent extends http.Agent {
   constructor (options) {
-    const { proxy, ...opts } = options
+    const { proxy, proxyRequestOptions, ...opts } = options
     super(opts)
     this.proxy = typeof proxy === 'string'
       ? new URL(proxy)
       : proxy
+    this.proxyRequestOptions = proxyRequestOptions || {}
   }
 
   createConnection (options, callback) {
     const requestOptions = {
+      ...this.proxyRequestOptions,
       method: 'CONNECT',
       host: this.proxy.hostname,
       port: this.proxy.port,
       path: `${options.host}:${options.port}`,
       setHost: false,
-      headers: { connection: this.keepAlive ? 'keep-alive' : 'close', host: `${options.host}:${options.port}` },
+      headers: { ...this.proxyRequestOptions.headers, connection: this.keepAlive ? 'keep-alive' : 'close', host: `${options.host}:${options.port}` },
       agent: false,
       timeout: options.timeout || 0
     }
@@ -60,21 +62,23 @@ class HttpProxyAgent extends http.Agent {
 
 class HttpsProxyAgent extends https.Agent {
   constructor (options) {
-    const { proxy, ...opts } = options
+    const { proxy, proxyRequestOptions, ...opts } = options
     super(opts)
     this.proxy = typeof proxy === 'string'
       ? new URL(proxy)
       : proxy
+    this.proxyRequestOptions = proxyRequestOptions || {}
   }
 
   createConnection (options, callback) {
     const requestOptions = {
+      ...this.proxyRequestOptions,
       method: 'CONNECT',
       host: this.proxy.hostname,
       port: this.proxy.port,
       path: `${options.host}:${options.port}`,
       setHost: false,
-      headers: { connection: this.keepAlive ? 'keep-alive' : 'close', host: `${options.host}:${options.port}` },
+      headers: { ...this.proxyRequestOptions.headers, connection: this.keepAlive ? 'keep-alive' : 'close', host: `${options.host}:${options.port}` },
       agent: false,
       timeout: options.timeout || 0
     }

--- a/test/http-http.test.js
+++ b/test/http-http.test.js
@@ -416,3 +416,94 @@ test('Username and password should not be encoded', async t => {
   server.close()
   proxy.close()
 })
+
+test('Proxy request options should be passed to the CONNECT request only', async t => {
+  const server = await createServer()
+  const proxy = await createProxy()
+  let serverCustomHeaderReceived
+  let proxyCustomHeaderReceived
+  server.on('request', (req, res) => {
+    serverCustomHeaderReceived = req.headers['x-custom-header']
+    return res.end('ok')
+  })
+  proxy.on('connect', (req) => {
+    proxyCustomHeaderReceived = req.headers['x-custom-header']
+  })
+
+  const response = await request({
+    method: 'GET',
+    hostname: server.address().address,
+    port: server.address().port,
+    path: '/',
+    agent: new HttpProxyAgent({
+      proxyRequestOptions: {
+        headers: {
+          'x-custom-header': 'value'
+        }
+      },
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: 256,
+      maxFreeSockets: 256,
+      scheduling: 'lifo',
+      proxy: `http://${proxy.address().address}:${proxy.address().port}`
+    })
+  })
+
+  let body = ''
+  response.setEncoding('utf8')
+  for await (const chunk of response) {
+    body += chunk
+  }
+
+  t.is(body, 'ok')
+  t.is(response.statusCode, 200)
+  t.falsy(serverCustomHeaderReceived)
+  t.is(proxyCustomHeaderReceived, 'value')
+
+  server.close()
+  proxy.close()
+})
+
+test('Proxy request options should not override internal default options for CONNECT request', async t => {
+  const server = await createServer()
+  const proxy = await createProxy()
+  let proxyConnectionHeaderReceived
+  server.on('request', (req, res) => res.end('ok'))
+  proxy.on('connect', (req) => {
+    proxyConnectionHeaderReceived = req.headers.connection
+  })
+
+  const response = await request({
+    method: 'GET',
+    hostname: server.address().address,
+    port: server.address().port,
+    path: '/',
+    agent: new HttpProxyAgent({
+      proxyRequestOptions: {
+        headers: {
+          connection: 'close'
+        }
+      },
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: 256,
+      maxFreeSockets: 256,
+      scheduling: 'lifo',
+      proxy: `http://${proxy.address().address}:${proxy.address().port}`
+    })
+  })
+
+  let body = ''
+  response.setEncoding('utf8')
+  for await (const chunk of response) {
+    body += chunk
+  }
+
+  t.is(body, 'ok')
+  t.is(response.statusCode, 200)
+  t.is(proxyConnectionHeaderReceived, 'keep-alive')
+
+  server.close()
+  proxy.close()
+})

--- a/test/http-https.test.js
+++ b/test/http-https.test.js
@@ -341,3 +341,94 @@ test('Timeout', async t => {
   server.close()
   proxy.close()
 })
+
+test('Proxy request options should be passed to the CONNECT request only', async t => {
+  const server = await createSecureServer()
+  const proxy = await createProxy()
+  let serverCustomHeaderReceived
+  let proxyCustomHeaderReceived
+  server.on('request', (req, res) => {
+    serverCustomHeaderReceived = req.headers['x-custom-header']
+    return res.end('ok')
+  })
+  proxy.on('connect', (req) => {
+    proxyCustomHeaderReceived = req.headers['x-custom-header']
+  })
+
+  const response = await request({
+    method: 'GET',
+    hostname: SERVER_HOSTNAME,
+    port: server.address().port,
+    path: '/',
+    agent: new HttpsProxyAgent({
+      proxyRequestOptions: {
+        headers: {
+          'x-custom-header': 'value'
+        }
+      },
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: 256,
+      maxFreeSockets: 256,
+      scheduling: 'lifo',
+      proxy: `http://${proxy.address().address}:${proxy.address().port}`
+    })
+  })
+
+  let body = ''
+  response.setEncoding('utf8')
+  for await (const chunk of response) {
+    body += chunk
+  }
+
+  t.is(body, 'ok')
+  t.is(response.statusCode, 200)
+  t.falsy(serverCustomHeaderReceived)
+  t.is(proxyCustomHeaderReceived, 'value')
+
+  server.close()
+  proxy.close()
+})
+
+test('Proxy request options should not override internal default options for CONNECT request', async t => {
+  const server = await createSecureServer()
+  const proxy = await createProxy()
+  let proxyConnectionHeaderReceived
+  server.on('request', (req, res) => res.end('ok'))
+  proxy.on('connect', (req) => {
+    proxyConnectionHeaderReceived = req.headers.connection
+  })
+
+  const response = await request({
+    method: 'GET',
+    hostname: SERVER_HOSTNAME,
+    port: server.address().port,
+    path: '/',
+    agent: new HttpsProxyAgent({
+      proxyRequestOptions: {
+        headers: {
+          connection: 'close'
+        }
+      },
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: 256,
+      maxFreeSockets: 256,
+      scheduling: 'lifo',
+      proxy: `http://${proxy.address().address}:${proxy.address().port}`
+    })
+  })
+
+  let body = ''
+  response.setEncoding('utf8')
+  for await (const chunk of response) {
+    body += chunk
+  }
+
+  t.is(body, 'ok')
+  t.is(response.statusCode, 200)
+  t.is(proxyConnectionHeaderReceived, 'keep-alive')
+
+  server.close()
+  proxy.close()
+})

--- a/test/https-https.test.js
+++ b/test/https-https.test.js
@@ -378,3 +378,94 @@ test('Username and password should not be encoded', async t => {
   server.close()
   proxy.close()
 })
+
+test('Proxy request options should be passed to the CONNECT request only', async t => {
+  const server = await createSecureServer()
+  const proxy = await createSecureProxy()
+  let serverCustomHeaderReceived
+  let proxyCustomHeaderReceived
+  server.on('request', (req, res) => {
+    serverCustomHeaderReceived = req.headers['x-custom-header']
+    return res.end('ok')
+  })
+  proxy.on('connect', (req) => {
+    proxyCustomHeaderReceived = req.headers['x-custom-header']
+  })
+
+  const response = await request({
+    method: 'GET',
+    hostname: SERVER_HOSTNAME,
+    port: server.address().port,
+    path: '/',
+    agent: new HttpsProxyAgent({
+      proxyRequestOptions: {
+        headers: {
+          'x-custom-header': 'value'
+        }
+      },
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: 256,
+      maxFreeSockets: 256,
+      scheduling: 'lifo',
+      proxy: `https://${PROXY_HOSTNAME}:${proxy.address().port}`
+    })
+  })
+
+  let body = ''
+  response.setEncoding('utf8')
+  for await (const chunk of response) {
+    body += chunk
+  }
+
+  t.is(body, 'ok')
+  t.is(response.statusCode, 200)
+  t.falsy(serverCustomHeaderReceived)
+  t.is(proxyCustomHeaderReceived, 'value')
+
+  server.close()
+  proxy.close()
+})
+
+test('Proxy request options should not override internal default options for CONNECT request', async t => {
+  const server = await createSecureServer()
+  const proxy = await createSecureProxy()
+  let proxyConnectionHeaderReceived
+  server.on('request', (req, res) => res.end('ok'))
+  proxy.on('connect', (req) => {
+    proxyConnectionHeaderReceived = req.headers.connection
+  })
+
+  const response = await request({
+    method: 'GET',
+    hostname: SERVER_HOSTNAME,
+    port: server.address().port,
+    path: '/',
+    agent: new HttpsProxyAgent({
+      proxyRequestOptions: {
+        headers: {
+          connection: 'close'
+        }
+      },
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: 256,
+      maxFreeSockets: 256,
+      scheduling: 'lifo',
+      proxy: `https://${PROXY_HOSTNAME}:${proxy.address().port}`
+    })
+  })
+
+  let body = ''
+  response.setEncoding('utf8')
+  for await (const chunk of response) {
+    body += chunk
+  }
+
+  t.is(body, 'ok')
+  t.is(response.statusCode, 200)
+  t.is(proxyConnectionHeaderReceived, 'keep-alive')
+
+  server.close()
+  proxy.close()
+})


### PR DESCRIPTION
This PR adds a new property to the constructor `options`, `proxyRequestOptions`, which allows callers to provide options for  the 
 CONNECT request made against the proxy. There are various reasons to do this:
- A custom `ca` may need to be passed to the proxy connection but not the upstream connection (or vice versa) and the `ca` value is not known at launch or can change over time, preventing the use of `NODE_EXTRA_CA_CERTS` as a viable alternative because that environment variable is only used by Node during startup
- Specific proxy headers may need to be sent which differ from the upstream request; for instance, `Proxy-Authentication` should be sent only to the proxy and `Authorization` should only be sent to the upstream server.

Implements #69 
Note: this PR introduces a merge conflict with #71. Whichever lands first will require a manual merge before the other can land.