### PR TITLE
POC: allow connect options to be passed to the proxy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare class HttpProxyAgent extends http.Agent {
 
 interface HttpProxyAgentOptions extends http.AgentOptions {
   proxy: string | URL
+  proxyOptions?: https.AgentOptions
 }
 
 declare class HttpsProxyAgent extends https.Agent {
@@ -16,6 +17,7 @@ declare class HttpsProxyAgent extends https.Agent {
 
 interface HttpsProxyAgentOptions extends https.AgentOptions {
   proxy: string | URL
+  proxyOptions?: https.AgentOptions
 }
 
 export {

--- a/index.js
+++ b/index.js
@@ -6,11 +6,12 @@ const { URL } = require('url')
 
 class HttpProxyAgent extends http.Agent {
   constructor (options) {
-    const { proxy, ...opts } = options
+    const { proxy, proxyOptions, ...opts } = options
     super(opts)
     this.proxy = typeof proxy === 'string'
       ? new URL(proxy)
       : proxy
+    this.proxyOptions = proxyOptions
   }
 
   createConnection (options, callback) {
@@ -22,7 +23,8 @@ class HttpProxyAgent extends http.Agent {
       setHost: false,
       headers: { connection: this.keepAlive ? 'keep-alive' : 'close', host: `${options.host}:${options.port}` },
       agent: false,
-      timeout: options.timeout || 0
+      timeout: options.timeout || 0,
+      ...this.proxyOptions
     }
 
     if (this.proxy.username || this.proxy.password) {
@@ -60,11 +62,12 @@ class HttpProxyAgent extends http.Agent {
 
 class HttpsProxyAgent extends https.Agent {
   constructor (options) {
-    const { proxy, ...opts } = options
+    const { proxy, proxyOptions, ...opts } = options
     super(opts)
     this.proxy = typeof proxy === 'string'
       ? new URL(proxy)
       : proxy
+    this.proxyOptions = proxyOptions
   }
 
   createConnection (options, callback) {
@@ -76,7 +79,8 @@ class HttpsProxyAgent extends https.Agent {
       setHost: false,
       headers: { connection: this.keepAlive ? 'keep-alive' : 'close', host: `${options.host}:${options.port}` },
       agent: false,
-      timeout: options.timeout || 0
+      timeout: options.timeout || 0,
+      ...this.proxyOptions
     }
 
     if (this.proxy.username || this.proxy.password) {


### PR DESCRIPTION
I'm looking to use this package in a product, but will need support to pass `rejectUnauthorized`, cert info, etc, into the proxy itself.  Right now, looking for the best approach to do this, and this is what I have so far.  Totally open for other approaches.

I noticed it's going to be hard to test things like `rejectUnauthorized` due to the various hacks in the tests - overriding DNS, etc :-) - been there, done that :heart:  

Probably we'd want a separate set of tests, that don't set global env vars, override DNS, etc.
