### PR TITLE
add "exports.types" for strict mode TS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "import": "./index.mjs"
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
     },
     "./*": "./*.js"
   },


### PR DESCRIPTION
Without this change i get

```
TS7016: Could not find a declaration file for module 'hpagent'.
'/Users/bowzee/WebstormProjects/trading.bot/node_modules/hpagent/index.mjs' implicitly has an 'any' type.
Try `npm i --save-dev @types/hpagent` if it exists or add a new declaration (.d.ts) file containing `declare module 'hpagent';`
```